### PR TITLE
mkdir before workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,12 @@ RUN jupyter labextension install jupyterlab-topbar-extension && \
 # Copy overrides.json to settings folder to enable save widget state as default
 RUN cp /tmp/config/overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
 
+USER root
+RUN mkdir /fastgenomics
+RUN chown -v -R 1000:100 /fastgenomics
+USER jovyan
 WORKDIR /fastgenomics
+
 RUN chown -v -R 1000:100 ~/.jupyter
 
 # import the default FG workspace


### PR DESCRIPTION
um die permissions zu switchen muss das workdir zunächst mit mkdir angelegt werden
siehe auch https://github.com/moby/moby/issues/36408#issuecomment-373477368

dann muss explizit `USER jovyan` verwendet werden, sonst laufen alle nachfolgenden Befehle als root und der jupyter server in `image_scanpy` motzt rum